### PR TITLE
Move remote relay smtp into init.php

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class nullmailer::config {
   }
 
   file { '/etc/nullmailer/remotes':
-    content => "$nullmailer::remoterelay smtp\n",
+    content => "$nullmailer::remoterelay\n",
     require => Class['nullmailer::package'],
     notify  => Class['nullmailer::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@ class nullmailer (
   $absentpackages = $nullmailer::params::absentpackages,
   $service = $nullmailer::params::service,
   $manage_etc_mailname = $nullmailer::params::manage_etc_mailname,
-  $adminaddr = "root@$::domain",
+  $adminaddr = "root@$::domain smtp",
   $remoterelay = "smtp.$::domain"
 
 ) inherits nullmailer::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,8 +3,8 @@ class nullmailer (
   $absentpackages = $nullmailer::params::absentpackages,
   $service = $nullmailer::params::service,
   $manage_etc_mailname = $nullmailer::params::manage_etc_mailname,
-  $adminaddr = "root@$::domain smtp",
-  $remoterelay = "smtp.$::domain"
+  $adminaddr = "root@$::domain",
+  $remoterelay = "smtp.$::domain smtp"
 
 ) inherits nullmailer::params {
 


### PR DESCRIPTION
Move the smtp part of the remoterelay configuration into init.pp so that it can be easily overwritten.

For example, in my config I wanted to use --port --user and --password.
