### PR TITLE
Please pull this patch to your package for security reason fix

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,9 @@ class nullmailer::config {
     content => "$nullmailer::remoterelay smtp $nullmailer::remoteopts\n",
     require => Class['nullmailer::package'],
     notify  => Class['nullmailer::service'],
+    owner   => 'mail',
+    group   => 'mail',
+    mode    => 0600,
   }
 
   if ($nullmailer::adminaddr == '') {


### PR DESCRIPTION
The file /etc/nullmailer/remotes is a file where also password could be
configured. Therefore the original file is owned by mail and only
readable by user mail.

If there is a global setting for owner and mode as defaults for file as
it is very common, this would leak the data to the world. Setting that
explicit for the file fixes this issue.
