### PR TITLE
Added basic testing framework

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  symlinks:
+    nullmailer: "#{source_dir}"
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Session.vim
 spec/fixtures
 .*.sw[a-z]
 *.un~
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+
+script: "bundle exec rake spec"
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.0.0"
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 3.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,26 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'rake',                    :require => false
+  gem 'rspec-puppet',            :require => false
+  gem 'puppetlabs_spec_helper',  :require => false
+  gem 'serverspec',              :require => false
+  gem 'rspec-system',            :require => false
+  gem 'rspec-system-puppet',     :require => false
+  gem 'rspec-system-serverspec', :require => false
+  gem 'puppet-lint',             :require => false
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+# vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Puppet module for nullmailer
 ============================
+[![Build Status](https://travis-ci.org/akumria/puppet-nullmailer.png)](https://travis-ci.org/akumria/puppet-nullmailer)
 
 Nullmailer is useful in situations where you have machines but do not wish
 to configure them with a full email service (mail transfer agent, MTA).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class nullmailer (
 ) inherits nullmailer::params {
 
   anchor {'nullmailer::start':}->
-  class {'nullmailer::package':}~>
+  class {'nullmailer::install':}~>
   class {'nullmailer::config':}~>
   class {'nullmailer::service':}~>
   anchor {'nullmailer::end':}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
-class nullmailer::package {
+class nullmailer::install {
   package { $nullmailer::package:
     ensure => present,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class nullmailer::params {
-  case $::operatingsystem {
-    /(Ubuntu|Debian)/: {
+  case $::osfamily {
+    'Debian': {
       $package = ['nullmailer', ]
       $absentpackages = [ 'exim4-daemon-light', 'exim4-daemon-heavy',
                           'postfix', 'sendmail-bin', 'citadel-mta',
@@ -10,7 +10,7 @@ class nullmailer::params {
       $manage_etc_mailname = true
     }
     default: {
-      fail("Unsupported platform: ${::operatingsystem}")
+      fail("Unsupported platform: ${::osfamily}")
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'nullmailer' do
+  context 'supported operating systems' do
+    ['Debian' ].each do |osfamily|
+      describe "nullmailer class without any parameters on #{osfamily}" do
+        let(:params) {{ }}
+        let(:facts) {{
+          :osfamily => osfamily
+        }}
+
+        it { should contain_class('nullmailer::params') }
+        it { should contain_class('nullmailer::install') }
+        it { should contain_class('nullmailer::config') }
+        it { should contain_class('nullmailer::service') }
+      end
+    end
+  end
+
+  context 'unsupported operating system' do
+    describe 'nullmailer class without any parameters on RedHat' do
+      let(:facts) {{
+        :osfamily        => 'RedHat',
+      }}
+
+      it { expect { should }.to raise_error(Puppet::Error) }
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,0 +1,1 @@
+include nullmailer


### PR DESCRIPTION
This adds the basic boilerplate to test this module with:

```
bundle install
bundle exec rake spec
```

It also includes .travis stuff which integrates well with Github.

I also changed the install class from "package" to "install" and keyed off of `$::osfamily` instead of `$::operatingsystem` to conform to more standard module best practice stuff. (hope that is ok)

Closes #7.
